### PR TITLE
Python3-compatible version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 *.db
+.idea
+.DS_Store
+


### PR DESCRIPTION
Let's see what Travis says. Tests pass with Python3 and Python2 in my environment.
Anyway it can certainly still be improved. I see at least:
- With Python2 there are warnings that I don't know how to handle from sqlalchemy: `.../python2.7/site-packages/sqlalchemy/sql/sqltypes.py:185: SAWarning: Unicode type received non-unicode bind param value 'fff'. (this warning may be suppressed after 10 occurrences)
  (util.ellipses_string(value),))`
- Instead of an `if` in `from_bytes()`, use the same kind of function redefinition as in `b()`.
- Change more things in cyvcf2's output to type string instead of bytes (e.g. `impact headers['CSQ'/'EFF'/'ANN']`) for more consistency (keys are now strings) and to avoid some conversions.
- There may be some unnecessary conversions (in particular, I don't understand everything with the `"escape_unicode"` things).
