### PR TITLE
Remove superflous (and possibly dangerous) raise statement

### DIFF
--- a/vcf2db.py
+++ b/vcf2db.py
@@ -433,7 +433,6 @@ class VCFDB(object):
                                       print(k, v.__class___.__name__)
 
                                 raise e
-                    raise
         else:
             try:
                 self.engine.execute(stmt, objs)


### PR DESCRIPTION
When vcf2db hits an exception when inserting multiple records at a time,
it catches it then inserts single records, and if an exception occurs,
prints the record as bad before raising the exception itself.

However, there are cases where the batch insertion fails, and the
individual insertions succeed. In this case the code hits a second
`raise` statement and interrupts loading, even though no error has
occurred.

This commit removes the `raise` statement for these reasons:

- If an exception occurs and there is a bad record, the code will
catch it anyway;
- If an exception does *not* occur, execution can continue instead of
interrupting loading.

Note that this is a workaround more than a fix, since it is unclear why
adding record in batch would fail, while individual records would work.

Workarounds issue #59.